### PR TITLE
Fix leaks v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 *.su
 *.idb
 *.pdb
+vgcore.*
 
 # Kernel Module Compile Results
 *.mod*

--- a/src/yabi.c
+++ b/src/yabi.c
@@ -28,6 +28,11 @@ int main(void)
 
         printf("%zu\n", yabi_node_list_peek(my_list)->integer);
 
+        struct yabi_type *my_pop = yabi_node_list_pop(my_list);
+
+        printf("%zu\n", my_pop->integer);
+
+        yabi_destroy_element(my_pop);
         yabi_destroy_node_list(my_list);
 
         return EXIT_SUCCESS;

--- a/src/yabi.c
+++ b/src/yabi.c
@@ -10,22 +10,20 @@ int main(void)
 {
         struct yabi_node_list *my_list = yabi_create_node_list();
         struct yabi_node *int_node = yabi_create_integer_node(55);
-        struct yabi_node *string_node
-                = yabi_create_string_node("Hello node str");
+        struct yabi_node *str_node = yabi_create_string_node("Hewllo");
 
         yabi_node_list_append(my_list, int_node);
-        yabi_node_list_append(my_list, string_node);
+        yabi_node_list_append(my_list, str_node);
 
         printf("%zu\n", yabi_node_list_get_index(my_list, 0)->integer);
-        printf("%s\n", yabi_node_list_get_index(my_list, 1)->string->value);
 
-        yabi_node_list_remove_node(my_list, int_node);
+        // yabi_node_list_remove_node(my_list, int_node);
 
         struct yabi_type *last_elem = yabi_node_list_pop(my_list);
 
-        printf("%s\n", last_elem->string->value);
+        printf("%zu\n", last_elem->integer);
 
-        yabi_destroy_element(last_elem);
+        yabi_destroy_integer(last_elem);
         yabi_destroy_node_list(my_list);
 
         return EXIT_SUCCESS;

--- a/src/yabi.c
+++ b/src/yabi.c
@@ -15,15 +15,19 @@ int main(void)
         yabi_node_list_append(my_list, int_node);
         yabi_node_list_append(my_list, str_node);
 
-        printf("%zu\n", yabi_node_list_get_index(my_list, 0)->integer);
+        struct yabi_type *peek_node = yabi_node_list_peek(my_list);
 
-        // yabi_node_list_remove_node(my_list, int_node);
+        printf("%d\n", peek_node->type);
 
-        struct yabi_type *last_elem = yabi_node_list_pop(my_list);
+        yabi_node_list_remove_node(my_list, int_node);
+        yabi_node_list_remove_node(my_list, str_node);
 
-        printf("%zu\n", last_elem->integer);
+        struct yabi_node *int_node_two = yabi_create_integer_node(14);
 
-        yabi_destroy_integer(last_elem);
+        yabi_node_list_append(my_list, int_node_two);
+
+        printf("%zu\n", yabi_node_list_peek(my_list)->integer);
+
         yabi_destroy_node_list(my_list);
 
         return EXIT_SUCCESS;

--- a/src/yabi_node.c
+++ b/src/yabi_node.c
@@ -5,6 +5,7 @@
 #include "yabi_type.h"
 
 static void empty_node_list(struct yabi_node_list *list);
+static void destroy_node(struct yabi_node *node);
 
 struct yabi_node_list *yabi_create_node_list(void)
 {
@@ -57,6 +58,11 @@ struct yabi_node *yabi_create_node(struct yabi_type *element)
         ret->next = NULL;
 
         return ret;
+}
+
+static void destroy_node(struct yabi_node *node)
+{
+        free(node);
 }
 
 struct yabi_node *yabi_create_string_node(const char *string)
@@ -178,7 +184,7 @@ struct yabi_type *yabi_node_list_peek(struct yabi_node_list *list)
                 return NULL;
         }
 
-        return list->tail->element;
+        return list->head->element;
 }
 
 struct yabi_type *yabi_node_list_pop(struct yabi_node_list *list)
@@ -187,9 +193,12 @@ struct yabi_type *yabi_node_list_pop(struct yabi_node_list *list)
                 return NULL;
         }
 
-        struct yabi_type *ret = list->tail->element;
+        struct yabi_node *head = list->head;
+        struct yabi_type *ret = list->head->element;
 
-        yabi_node_list_remove_node(list, list->tail);
+        list->head = list->head->next;
+
+        destroy_node(head);
 
         return ret;
 }
@@ -220,4 +229,6 @@ void yabi_node_list_remove_node(struct yabi_node_list *list,
                 prev->next = NULL;
                 list->tail = prev;
         }
+
+        --list->length;
 }

--- a/src/yabi_node.c
+++ b/src/yabi_node.c
@@ -219,18 +219,18 @@ void yabi_node_list_remove_node(struct yabi_node_list *list,
         }
 
         if (list->length == 1) {
-                // Removing the only item in the list
+                /* Removing the only item in the list */
                 yabi_destroy_node(node);
                 list->head = NULL;
                 list->tail = NULL;
 
         } else if (node->next != NULL) {
-                // Removing item in the middle of the list
+                /* Removing item in the middle of the list */
                 struct yabi_node *tmp = node->next;
                 node->element = tmp->element;
                 node->next = tmp->next;
         } else {
-                // Removing node from the tail
+                /* Removing node from the tail */
                 struct yabi_node *current_node = list->head;
                 struct yabi_node *prev = list->head;
 

--- a/src/yabi_node.c
+++ b/src/yabi_node.c
@@ -131,13 +131,8 @@ void yabi_node_list_append(struct yabi_node_list *list, struct yabi_node *node)
                 list->head = node;
                 list->tail = node;
         } else {
-                struct yabi_node *current_node = list->head;
-                while (current_node->next != NULL) {
-                        current_node = current_node->next;
-                }
-
-                current_node->next = node;
-                list->tail = node;
+                node->next = list->head;
+                list->head = node;
         }
 
         ++list->length;
@@ -200,6 +195,12 @@ struct yabi_type *yabi_node_list_pop(struct yabi_node_list *list)
 
         destroy_node(head);
 
+        --list->length;
+
+        if (list->length == 0) {
+                list->tail = NULL;
+        }
+
         return ret;
 }
 
@@ -210,17 +211,30 @@ void yabi_node_list_remove_node(struct yabi_node_list *list,
                 return;
         }
 
-        if (node->next != NULL) {
+        if (list->length == 1) {
+                yabi_destroy_node(node);
+                list->head = NULL;
+                list->tail = NULL;
+                return;
+        }
+
+        if (list->length == 1) {
+                // Removing the only item in the list
+                yabi_destroy_node(node);
+                list->head = NULL;
+                list->tail = NULL;
+
+        } else if (node->next != NULL) {
+                // Removing item in the middle of the list
                 struct yabi_node *tmp = node->next;
                 node->element = tmp->element;
                 node->next = tmp->next;
-
-                yabi_destroy_node(tmp);
         } else {
+                // Removing node from the tail
                 struct yabi_node *current_node = list->head;
                 struct yabi_node *prev = list->head;
 
-                while (prev->next != NULL) {
+                while (current_node->next != NULL) {
                         prev = current_node;
                         current_node = current_node->next;
                 }

--- a/src/yabi_node.c
+++ b/src/yabi_node.c
@@ -212,13 +212,6 @@ void yabi_node_list_remove_node(struct yabi_node_list *list,
         }
 
         if (list->length == 1) {
-                yabi_destroy_node(node);
-                list->head = NULL;
-                list->tail = NULL;
-                return;
-        }
-
-        if (list->length == 1) {
                 /* Removing the only item in the list */
                 yabi_destroy_node(node);
                 list->head = NULL;


### PR DESCRIPTION
```
==32234== Memcheck, a memory error detector
==32234== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32234== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==32234== Command: ./bin/yabi.out
==32234==
0
14
14
==32234==
==32234== HEAP SUMMARY:
==32234==     in use at exit: 0 bytes in 0 blocks
==32234==   total heap usage: 9 allocs, 9 frees, 1,160 bytes allocated
==32234==
==32234== All heap blocks were freed -- no leaks are possible
==32234==
==32234== For counts of detected and suppressed errors, rerun with: -v
==32234== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```